### PR TITLE
Update `xdmod-ondemand-export` to version 1.0.0.

### DIFF
--- a/tools/xdmod-ondemand-export/docs/developing.md
+++ b/tools/xdmod-ondemand-export/docs/developing.md
@@ -22,9 +22,9 @@ After the Pull Request is approved, these steps should be run from the `tools/xd
     ```
     python3 -m build --wheel
     ```
-1. Upload the built distribution to PyPI, e.g., for version 1.0.0-beta2:
+1. Upload the built distribution to PyPI, e.g., for version 1.0.0:
     ```
-    version=1.0.0b2
+    version=1.0.0
     twine upload dist/xdmod_ondemand_export-${version}-py3-none-any.whl
     ```
     Enter your PyPI username and password.

--- a/tools/xdmod-ondemand-export/xdmod_ondemand_export/__init__.py
+++ b/tools/xdmod-ondemand-export/xdmod_ondemand_export/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "xdmod-ondemand-export"
-__version__ = "1.0.0-beta.2"
+__version__ = "1.0.0"
 __description__ = (
     "POST Open OnDemand logs to a web server for inclusion in XDMoD."
 )


### PR DESCRIPTION
This PR updates the `xdmod-ondemand-export` tool to version 1.0.0, which is identical to version 1.0.0-beta.2.