### PR TITLE
Send application lists in addition to logs.

### DIFF
--- a/tools/xdmod-ondemand-export/CHANGELOG.md
+++ b/tools/xdmod-ondemand-export/CHANGELOG.md
@@ -1,0 +1,7 @@
+# xdmod-ondemand-export Changelog
+
+## Main development branch
+- Send application lists in addition to logs ([\#30](https://github.com/ubccr/xdmod-ondemand-export/pull/30)).
+
+## v1.0.0 (2023-10-18)
+- Initial release.


### PR DESCRIPTION
This PR updates the `xdmod-ondemand-export` tool to also send the lists of installed OnDemand applications.

This is desired so that the OnDemand team can track the lists of applications installed on the ACCESS OnDemand instances.

Here is an example POST body:
```
{
  "date": "2024-01-12",
  "version": "3.0.3",
  "system_apps": [
    "activejobs",
    "bc_desktop",
    "dashboard",
    "file-editor",
    "files",
    "myjobs",
    "shell"
  ],
  "shared_apps": [
    "matlab"
  ]
}
```