### PR TITLE
Add `User-Agent` header identifying the tool.

### DIFF
--- a/tools/xdmod-ondemand-export/CHANGELOG.md
+++ b/tools/xdmod-ondemand-export/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Send application lists in addition to logs ([\#30](https://github.com/ubccr/xdmod-ondemand/pull/30)).
 - Don't send lines containing 401 status code ([\#31](https://github.com/ubccr/xdmod-ondemand/pull/31)).
 - Don't send lines with empty users ([\#33](https://github.com/ubccr/xdmod-ondemand/pull/33)).
+- Add `User-Agent` header identifying the tool ([\#34](https://github.com/ubccr/xdmod-ondemand/pull/34)).
 
 ## v1.0.0 (2023-10-18)
 - Initial release.

--- a/tools/xdmod-ondemand-export/xdmod_ondemand_export/__init__.py
+++ b/tools/xdmod-ondemand-export/xdmod_ondemand_export/__init__.py
@@ -318,8 +318,9 @@ class LogPoster:
             self.__url,
             data=self.__parse_log_file(log_file_path, previous_line),
             headers={
-                'content-type': 'text/plain',
-                'authorization': 'Bearer ' + self.__api_token,
+                'Content-Type': 'text/plain',
+                'Authorization': 'Bearer ' + self.__api_token,
+                'User-Agent': __title__ + ' v' + __version__,
             },
         )
         self.__process_response(response)


### PR DESCRIPTION
This PR adds a `User-Agent` header for identifying the version of the `xdmod-ondemand-export` tool in server logs.