### PR TITLE
Remove instructions for obtaining API token.

### DIFF
--- a/tools/xdmod-ondemand-export/README.md
+++ b/tools/xdmod-ondemand-export/README.md
@@ -1,11 +1,6 @@
 # xdmod-ondemand-export
 Python script for parsing [Open OnDemand](https://openondemand.org/) Apache access logs and sending them via POST requests to an HTTPS endpoint on a web server for inclusion in [XDMoD](https://open.xdmod.org). It also sends lists of installed Open OnDemand apps for inventory by the Open OnDemand team.
 
-## Obtain an API token
-Obtain an API token from the admins of the destination web server; for ACCESS XDMoD, this is done by [submitting a ticket](https://support.access-ci.org/open-a-ticket):
-- For the "Summary" and "Description" you can say "Requesting xdmod-ondemand-export API token for [resource name]."
-- For "ACCESS Support Issue," choose "XDMoD Question."
-
 ## Installation
 The steps below explain the recommended setup, to be run as root on the system that has the Open OnDemand Apache access log files and lists of Open OnDemand apps (the latter in `/var/www/ood/apps`). The steps will create a new user called `xdmod-ondemand-export` with no shell or login access but which has read-only access to the logs (e.g., via Access Control List), install the Python package, and set up the files and permissions needed for the script to run.
 


### PR DESCRIPTION
API token distributions are being coordinated directly with RPs.