### PR TITLE
Fix root page redirect.

### DIFF
--- a/10.0/overview.md
+++ b/10.0/overview.md
@@ -1,7 +1,6 @@
 ---
 redirect_from:
     - "/10.0/"
-    - ""
 ---
 The XDMoD Open OnDemand Module is an optional module for
 tracking usage of the Open OnDemand software in XDMoD.


### PR DESCRIPTION
Currently, https://ondemand.xdmod.org/ redirects to https://ondemand.xdmod.org/10.0/overview.html instead of https://ondemand.xdmod.org/10.5/overview.html.

This is because both `10.0/overview.md` and `10.5/overview.md` have redirects from `""`, and the `10.0` site appears to have won a race condition.

This PR fixes this by removing the redirect from `10.0/overview.md`.