### PR TITLE
Update website to 11.0.

### DIFF
--- a/11.0/configuration.md
+++ b/11.0/configuration.md
@@ -1,0 +1,59 @@
+
+## Prerequisites
+
+The OnDemand module must be [installed](install.md). Optionally a GeoLite2
+geolocation database file can be [installed](requirements.md).
+
+## Database Configuration
+
+### Interactive script configuration
+
+The Open OnDemand XDMoD module adds an additional menu item to the XDMoD interactive setup software. Run the script as follows:
+
+    # xdmod-setup
+
+and select the ‘Open OnDemand’ option in the main menu. The Open OnDemand
+section only has a single option: setup the database.  This option creates the
+necessary database schema in the XDMoD
+datawarehouse. You will need to provide the credentials for your MySQL root
+user, or another user that has privileges to create databases. A single
+database `modw_ondemand` will be created.  The database user that is
+specified in the `portal_settings.ini` will be granted access to this
+database.
+
+### Manual configuration
+
+If the database server is located on a different host than the webserver then it is necessary
+to setup the database manually.
+
+Create a database schema called `modw_ondemand` and grant permission for the XDMoD database user
+account to access this schema.
+
+Once the schema is created then the `acl-config` command should be run:
+
+    $ /usr/xdmod/bin/acl-config
+
+## Resource Setup
+
+Add a new resource to Open XDMoD using the `xdmod-setup` script.
+Instructions for adding the resource are on the [main Open XDMoD page](https://open.xdmod.org/{{ page.version }}/configuration.html#resources)
+
+The Open OnDemand resource must have a type set to `gateway`.
+
+The resource setup menu will prompt for the node and core count for the resource. These
+data are not currently used by the On Demand module, but it is recommmended to use the
+correct core and node counts for the Open OnDemand webserver for consistency.
+
+**The `xdmod-ingestor` script must be run after the new resource is added**. Running
+`xdmod-ingestor` loads the resource information into the XDMoD datawarehouse.
+
+## Configuration file
+
+The `/etc/xdmod/portal_settings.d/ondemand.ini` configuration
+file settting are listed below:
+
+| Parameter Name |  Description
+| -------------- | -----------
+| `geoip_database`       | Full path to the GeoLite2 City file (in MMDB format). Set this to an empty string if no file is available (location data in XDMoD will show as Unknown). |
+| `webserver_format_str` | The format string for the webserver access logs. This should be set to the same value as the `LogFormat` directive in the apache server for the Open OnDemand instance |
+

--- a/11.0/faq.md
+++ b/11.0/faq.md
@@ -1,0 +1,26 @@
+
+## The OnDemand realm does not show in the XDMoD portal
+
+Make sure you are logged in with a user account that has either Center Director
+or Center Staff role. Note the admin user account that is created with `xdmod-setup`
+ does not have these roles by default.
+
+## The xdmod-ondemand-ingestor command ran without error, but no data
+
+Re-run the `xdmod-ondemand-ingestor` command with the `--debug` flag to show detailed information
+about what it is running. Things to double check:
+- The `webserver_format_str` setting matches the data format in the log files
+- The filenames of the log files end in `.log` or `.log.N` where `N` is a number
+
+## The xdmod-ondemand-ingestor command fails with out of memory error
+
+If the memory usage of the `xdmod-ondemand-ingestor` command reaches the php memory limit
+then it will exit with an error message similar to the one shown below
+```
+PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 86 bytes) in /usr/share/xdmod/vendor/kassner/log-parser/src/Kassner/LogParser/LogParser.php on line 113
+2021-08-10 18:52:16 [critical] Allowed memory size of 134217728 bytes exhausted (tried to allocate 86 bytes) (file: /usr/share/xdmod/vendor/kassner/log-parser/src/Kassner/LogParser/LogParser.php, line: 113, type: 1)
+```
+This memory error is caused because the `xdmod-ondemand-ingestor` command loads all records in a
+log file into memory before loading into the database. This error can be mitigated by either
+splitting the log file into multiple smaller files (described in the [Hints](ingestion-aggregation.md#hints)) or
+by increasing the php memory limit setting.

--- a/11.0/ingestion-aggregation.md
+++ b/11.0/ingestion-aggregation.md
@@ -1,0 +1,38 @@
+## Prerequisites:
+1. The OnDemand module [installed](install.md)
+2. The database schema has been [created](configuration.md#database-configuration)
+3. The OnDemand resource has been [added](configuration.md#resource-setup)
+4. The `portal_settings.d/ondemand.ini` configuration file [edited as needed](configuration.md#configuration-file)
+
+## Ingest and Aggregate
+
+The OnDemand weblog ingestion pipeline requires two parameters:
+
+| Parameter Name | Description
+| -------------- | -----------
+| `-r` or `--resource` | Must be set to the name of the resource when it was added to XDMoD in the `xdmod-setup` command. |
+| `-d` or `--dir` | Set to the path to a directory containing webserver log files from the Open OnDemand server. The ingestor will process all files in this directory that have the suffix `.log` or `.log.X` where X is a number |
+
+
+The pipeline should be run as the `xdmod` user as follows:
+
+    xdmod-ondemand-ingestor -d /path/to/ood_server_logs -r [resource]
+
+The ingestion and aggregation pipelines can also be run independently of each other. To run only the ingestion pipeline, include the `-i` or `--ingest` parameter, e.g.:
+
+    xdmod-ondemand-ingestor -d /path/to/ood_server_logs -r [resource] -i
+
+The run only the aggregation pipeline, include the `-a` or `--aggregate` parameter along with the `-m` or `--last-modified-start-date` parameter. In this case the `-d` and `-r` parameters will be ignored. E.g.:
+
+    xdmod-ondemand-ingestor -a -m '2024-01-01 00:00:00'
+
+### Hints
+
+For log files with a large amount of data (hundreds of thousands of lines), the ingestion pipeline
+will use less memory and run faster if you split large log files into smaller ones. An example of how to do this
+is to use the `split` commandline tool to split the large log file by lines and generate
+output files with a numbered suffix (note the period at the end of the output filename):
+
+```bash
+split -d -l 20000 [LARGE INPUT FILE] /scratch/ondemand/webserver.log.
+```

--- a/11.0/install.md
+++ b/11.0/install.md
@@ -1,0 +1,23 @@
+## Prerequisites
+
+The OnDemand module should be added to an existing working instance of
+Open XDMoD version {{ page.version }} or later. See the [Open XDMoD site](https://open.xdmod.org/)
+for setup and install instructions.
+
+## Source code install
+
+The source package is installed as follows:
+
+    $ tar zxvf xdmod-ondemand-{{ page.sw_version }}.tar.gz
+    $ cd xdmod-ondemand-{{ page.sw_version }}
+    # ./install --prefix=/opt/xdmod
+
+Change the prefix as desired. The default installation prefix is `/usr/local/xdmod`. These instructions assume you are installing Open XDMoD in `/opt/xdmod`.
+
+## RPM install
+
+    # yum install xdmod-ondemand-{{ page.sw_version }}-1.0.el7.noarch.rpm
+
+## Next Step
+
+[Configure](configuration.md) the package.

--- a/11.0/overview.md
+++ b/11.0/overview.md
@@ -1,6 +1,7 @@
 ---
 redirect_from:
-    - "/10.5/"
+    - "/11.0/"
+    - ""
 ---
 The XDMoD Open OnDemand Module is an optional module for
 tracking usage of the Open OnDemand software in XDMoD.

--- a/11.0/recategorizing-applications.md
+++ b/11.0/recategorizing-applications.md
@@ -1,0 +1,381 @@
+XDMoD automatically categorizes page impressions by application. This
+categorization is imperfect since it depends on pre-defined filters that are
+not aware of all possible applications. After page impressions have been
+ingested, you may wish to change their categorization. For example, they may
+have been categorized as "Unknown" when you would be able to properly
+categorize them manually given their request paths. For example, if you know
+the request path `/node/[host]/[port]/foo/bar` matches the `foo` application,
+you may wish to add a filter that assigns the `foo` application to any page
+impressions with that request path, and apply that filter to all the previously
+ingested page impressions without having to reingest the original log files.
+
+To help with recategorization, as page impressions are ingested, their distinct
+request paths are kept in the `modw_ondemand.request_path` database table, with
+a `request_path_id` foreign key in the `modw_ondemand.page_impressions` fact
+table. These can be used to recategorize previously ingested page
+impressions by selecting all the page impressions that have certain request
+paths and reassigning an application to them (instructions for doing this are
+further down).
+
+In the cases where multiple distinct request paths can be grouped together in a
+general form without losing any relevant information (e.g., `/foo?a=b`,
+`/foo?c=d`, and `/foo?e=f` might all be generalized as `/foo?[params]`), there
+is a configuration file that filters request paths into general forms such that
+they appear in the `modw_ondemand.request_path` table as, e.g.,
+`/foo?[params]`. You may wish to recategorize groups of request paths into a
+more general form to keep the size of this table smaller and to simplify the
+query for recategorizing applications of a general form (instructions for
+doing this are immediately below).
+
+## Recategorizing future request paths
+
+The file used for filtering request paths into more general forms is in the
+configuration directory (whose location depends on how you configured your
+installation, e.g., `/etc/xdmod`, `/opt/xdmod/etc`) under
+`etl/etl_data.d/ood/request-path-filter.json`. This file contains a JSON object
+whose keys are regular expressions used for matching against request paths from
+the ingested logs, and whose values are the corresponding general forms that
+will be stored in the database and assigned to future page impressions when
+they are ingested. Edit this file to configure the filter how you wish.
+
+If you have multiple OnDemand resources configured in XDMoD, you can also
+filter request paths on a per-resource basis by having other similar files at
+`etl/etl_data.d/ood/request-path-filter.d/${OOD_RESOURCE_CODE}.json`, where
+`${OOD_RESOURCE_CODE}` matches the value passed via the `-r` argument to
+`xdmod-ondemand-ingestor` (see the [ingestion and aggregation
+instructions](ingestion-aggregation.md)). Any keys that are the same between
+these files and the main `request-path-filter.json` will have their values
+override the values in the main `request-path-filter.json`.
+
+## Recategorizing existing request paths
+
+To apply a new filter to page impressions that have already been ingested,
+follow the instructions below to run some SQL statements in the XDMoD data
+warehouse.
+
+First you will want to back up the `modw_ondemand.page_impressions` and
+`modw_ondemand.request_path` tables (e.g., using `mysqldump`) so that you can
+restore the backups if something goes wrong that cannot be undone during these
+steps.
+
+Get the current timestamp prior to running any statements. Save this timestamp
+somewhere. Later, you will use it when you re-aggregate all page impressions
+modified after it.
+
+```sql
+SELECT CURRENT_TIMESTAMP();
+```
+
+Set some variables that will be used in subsequent statements. Replace the
+values below; set the desired regex from the filter and the desired generalized
+request path. Be careful that if the regex from the filter contains a grouping
+that gets backreferenced in the general form (e.g., `$1`) that you only run all
+these instructions for one member of the grouping at a time (e.g., if the regex
+is `a/(b|c|d)/e` and the general form is `a/[foo]/e`, make sure to run all
+these instructions once with the filter set to `a/b/e`, once with it set to
+`a/c/e`, and once with it set to `a/d/e`):
+
+```sql
+SET @request_path_filter = '^/rnode/[^/]+/[^/]+(/data/plugin/images/images\\?).+';
+SET @general_request_path = '/rnode/[host]/[port]/data/plugin/images/images?[params]';
+```
+
+Set locks for the tables you will be modifying, so that the automatic ingestion
+pipeline does not try to modify the tables at the same time you are:
+
+```sql
+LOCK TABLES
+modw_ondemand.page_impressions WRITE,
+modw_ondemand.page_impressions AS p WRITE,
+modw_ondemand.request_path WRITE,
+modw_ondemand.request_path AS rp READ;
+```
+
+Insert the new request path into `modw_ondemand.request_path` table and get its
+ID:
+
+```sql
+INSERT INTO modw_ondemand.request_path (path)
+VALUES (@general_request_path);
+SET @request_path_id = (
+    SELECT id
+    FROM modw_ondemand.request_path
+    WHERE path = @general_request_path
+);
+```
+
+If a `Duplicate entry` error occurs, it just means the request path is already
+in the table; you can continue with the instructions below.
+
+Create a temporary table containing all the page impressions whose path matches
+the filter but which don't already have the general form:
+
+```sql
+CREATE TEMPORARY TABLE modw_ondemand.tmp_request_path_updates AS SELECT p.*, rp.path
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+WHERE rp.path REGEXP @request_path_filter
+AND rp.path != @general_request_path;
+```
+
+Select all the rows from the temporary table and confirm it is a correct list
+of page impressions whose request path should be set to the general form:
+
+```sql
+SELECT * FROM modw_ondemand.tmp_request_path_updates;
+```
+
+Then, set the corresponding new `request_path_id` in the `page_impressions`
+table, ignoring any rows that are now duplicates:
+
+```sql
+UPDATE IGNORE modw_ondemand.tmp_request_path_updates AS t
+JOIN modw_ondemand.page_impressions AS p ON p.id = t.id
+SET p.request_path_id = @request_path_id;
+```
+
+Confirm it worked, noting that some rows may not have been updated because they
+are now duplicates of other rows:
+
+```sql
+SELECT p.*, rp.path
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+WHERE rp.path REGEXP @request_path_filter;
+```
+
+Select any rows that are duplicates:
+
+```sql
+SELECT p.*, rp.path
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+WHERE rp.path REGEXP @request_path_filter
+AND rp.path != @general_request_path;
+```
+
+And delete those:
+
+```sql
+DELETE p
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+WHERE rp.path REGEXP @request_path_filter
+AND rp.path != @general_request_path;
+```
+
+Confirm it worked:
+
+```sql
+SELECT p.*, rp.path
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+WHERE rp.path REGEXP @request_path_filter;
+```
+
+And drop the temporary table:
+
+```sql
+DROP TABLE modw_ondemand.tmp_request_path_updates;
+```
+
+Mark all the page impressions that have the general form as being modified
+so they can be reaggregated later, since some may not have been modified
+because they were duplicates of ones that were deleted:
+
+```sql
+UPDATE modw_ondemand.page_impressions
+SET last_modified = CURRENT_TIMESTAMP()
+WHERE request_path_id = @request_path_id;
+```
+
+Next, select the rows from the `request_path` table that match the filter:
+
+```sql
+SELECT *
+FROM request_path
+WHERE path REGEXP @request_path_filter
+AND id != @request_path_id;
+```
+
+If those rows look correct to delete, run the SQL statement below to delete
+them (the same statement as immediately above but replacing `SELECT *` with
+`DELETE`).
+
+```sql
+DELETE
+FROM request_path
+WHERE path REGEXP @request_path_filter
+AND id != @request_path_id;
+```
+
+Finally, unlock the tables:
+
+```sql
+UNLOCK TABLES;
+```
+
+## Recategorizing future applications
+
+The file used for mapping applications is in the configuration directory (whose
+location depends on how you configured your installation, e.g., `/etc/xdmod`,
+`/opt/xdmod/etc`) under `etl/etl_data.d/ood/application-map.json`. This
+file contains a JSON object whose keys are regular expressions used for
+matching against request paths from the ingested logs, and whose values are the
+corresponding applications that will be stored in the database and assigned to
+future page impressions when they are ingested. Edit this file to configure the
+application map how you wish.
+
+If you have multiple OnDemand resources configured in XDMoD, you can also
+map applications on a per-resource basis by having other similar files at
+`etl/etl_data.d/ood/application-map.d/${OOD_RESOURCE_CODE}.json`, where
+`${OOD_RESOURCE_CODE}` matches the value passed via the `-r` argument to
+`xdmod-ondemand-ingestor` (see the [ingestion and aggregation
+instructions](ingestion-aggregation.md)). Any keys that are the same between
+these files and the main `application-map.json` will have their values
+override the values in the main `application-map.json`.
+
+## Recategorizing existing applications
+
+To recategorize applications for page impressions that have already been
+ingested, follow the instructions below to run some SQL statements in the XDMoD
+data warehouse.
+
+First you will want to back up the `modw_ondemand.page_impressions` and
+`modw_ondemand.app` tables (e.g., using `mysqldump`) so that you can
+restore the backups if something goes wrong that cannot be undone during these
+steps.
+
+Get the current timestamp prior to running any statements (if you already did
+this above when recategorizing request paths, keep that one instead). Save this
+timestamp somewhere. Later, you will use it when you re-aggregate all page
+impressions modified after it.
+
+```sql
+SELECT CURRENT_TIMESTAMP();
+```
+
+Get the list of all apps so you can get the IDs of the app whose ID you want
+to change and the ID of the app to which you want to change it.
+
+```sql
+SELECT * FROM modw_ondemand.app;
+```
+
+Set some variables that will be used in subsequent statements. Set
+`@request_path_filter` to a regex that will be used to match page impressions
+whose request paths have a general form. Set `@old_app_id` to the current app
+ID of the page impressions you want to change. Set `@new_app_id` to the ID of
+the app to which you want to change them.
+
+```sql
+SET @request_path_filter = '^/rnode/[^/]+/[^/]+/(proxy/[^/]+/)?(data|experiment)/.*';
+SET @old_app_id = 8;
+SET @new_app_id = 7;
+```
+
+Get the list of page impressions that will be changed:
+
+```sql
+SELECT *
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+JOIN modw_ondemand.app AS a ON a.id = p.app_id
+WHERE p.app_id = @old_app_id
+AND rp.path REGEXP @request_path_filter;
+```
+
+If the list is correct, set locks for the tables you will be modifying, so that
+the automatic ingestion pipeline does not try to modify the tables at the same
+time you are:
+
+```sql
+LOCK TABLES
+modw_ondemand.page_impressions AS p WRITE,
+modw_ondemand.request_path AS rp READ,
+modw_ondemand.app AS a READ;
+```
+
+Change the app ID from old to new, ignoring any rows that are now duplicates:
+
+```sql
+UPDATE IGNORE modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+SET p.app_id = @new_app_id
+WHERE p.app_id = @old_app_id
+AND rp.path REGEXP @request_path_filter;
+```
+
+Confirm it worked:
+
+```sql
+SELECT *
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+JOIN modw_ondemand.app AS a ON a.id = p.app_id
+WHERE p.app_id = @new_app_id
+AND rp.path REGEXP @request_path_filter;
+```
+
+Select any rows that are duplicates:
+
+```sql
+SELECT *
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+JOIN modw_ondemand.app AS a ON a.id = p.app_id
+WHERE p.app_id = @old_app_id
+AND rp.path REGEXP @request_path_filter;
+```
+
+And delete those:
+
+```sql
+DELETE p
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+JOIN modw_ondemand.app AS a ON a.id = p.app_id
+WHERE p.app_id = @old_app_id
+AND rp.path REGEXP @request_path_filter;
+```
+
+Confirm there is now an empty set of duplicates:
+
+```sql
+SELECT *
+FROM modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+JOIN modw_ondemand.app AS a ON a.id = p.app_id
+WHERE p.app_id = @old_app_id
+AND rp.path REGEXP @request_path_filter;
+```
+
+Mark all the page impressions whose request path has the general form as being
+modified so they can be reaggregated later, since some may not have been
+modified because they were duplicates of ones that were deleted:
+
+```sql
+UPDATE modw_ondemand.page_impressions AS p
+JOIN modw_ondemand.request_path AS rp ON rp.id = p.request_path_id
+SET last_modified = CURRENT_TIMESTAMP()
+WHERE p.app_id = @new_app_id
+AND rp.path REGEXP @request_path_filter;
+```
+
+And unlock the tables:
+
+```sql
+UNLOCK TABLES;
+```
+
+## Reaggregating
+
+After you have run all the SQL statements, use the `xdmod-ondemand-ingestor`
+shell command to re-aggregate all of the page impressions that were modified
+after the value for `CURRENT_TIMESTAMP()` that you obtained above (replace
+`'2024-05-09 14:10:33'` in the example below):
+
+```sh
+$ xdmod-ondemand-ingestor -a -m '2024-05-09 14:10:33'
+```
+

--- a/11.0/requirements.md
+++ b/11.0/requirements.md
@@ -1,0 +1,21 @@
+
+The OnDemand module supports inferring geographic location based on the IP
+address in the Open OnDemand logs. The IP address to location lookup uses
+a GeoLite2 City binary database (MMDB) file, which is not supplied and must be downloaded
+separately. 
+
+
+The XDMoD OnDemand module has been tested with [MaxMind's free GeoLite2 City database](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data).
+
+The MMDB file should be saved in a path that the `xdmod` user account has read
+access.  The MMDB file is read by the process that loads information into XDMoD
+datawarehouse.
+
+An MMDB database file is only required for, and used by, the location lookup
+when log data are loaded into XDMoD.  If no database file is available, then
+the location information for all sessions will show as 'Unknown'. However
+all of the other data dimensions are unaffected.
+
+## Next Step
+
+Next [install](install.md) the package.

--- a/_config.yml
+++ b/_config.yml
@@ -23,15 +23,26 @@ url: "http://ondemand.xdmod.org" # the base hostname & protocol for your site
 github_username: ubccr
 github_url: https://github.com/ubccr/xdmod-ondemand
 xdmod_module_name: OnDemand
-latest_version: "10.5"
-latest_sw_version: "10.5.0"
+latest_version: "11.0"
+latest_sw_version: "11.0.0"
 version_list:
+  - "11.0"
   - "10.5"
 unsupported_version_list:
   - "10.0"
   - "9.5"
 
 defaults:
+  -
+    scope:
+      path: "11.0"
+      type: "pages"
+    values:
+      layout: "page"
+      version: "11.0"
+      sw_version: "11.0.0"
+      style: "effervescence"
+      tocversion: "v11_0toc"
   -
     scope:
       path: "10.5"

--- a/_data/v11_0toc.yml
+++ b/_data/v11_0toc.yml
@@ -19,8 +19,8 @@ toc:
     subfolderitems:
       - page: Ingestion and Aggregation
         url: /11.0/ingestion-aggregation.html
-      - page: Reclassifying Applications
-        url: /11.0/reclassifying-applications.html
+      - page: Recategorizing Applications
+        url: /11.0/recategorizing-applications.html
   - title: Help
     subfolderitems:
       - page: FAQ

--- a/_data/v11_0toc.yml
+++ b/_data/v11_0toc.yml
@@ -1,0 +1,27 @@
+toc:
+  - title: About
+    subfolderitems:
+      - page: Overview
+        url: /11.0/overview.html
+  - title: Download
+    subfolderitems:
+      - page: Open OnDemand module
+        url: https://github.com/ubccr/xdmod-ondemand/releases/latest
+  - title: Installing
+    subfolderitems:
+      - page: Software Requirements
+        url: /11.0/requirements.html
+      - page: Installation Guide
+        url: /11.0/install.html
+      - page: Configuration Guide
+        url: /11.0/configuration.html
+  - title: Using
+    subfolderitems:
+      - page: Ingestion and Aggregation
+        url: /11.0/ingestion-aggregation.html
+      - page: Reclassifying Applications
+        url: /11.0/reclassifying-applications.html
+  - title: Help
+    subfolderitems:
+      - page: FAQ
+        url: /11.0/faq.html

--- a/configuration.md
+++ b/configuration.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /10.5/configuration.html
+redirect_to: /11.0/configuration.html
 ---

--- a/faq.md
+++ b/faq.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /10.5/faq.html
+redirect_to: /11.0/faq.html
 ---

--- a/ingestion-aggregation.md
+++ b/ingestion-aggregation.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /11.0/ingestion-aggregation.html
+---

--- a/install.md
+++ b/install.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /10.5/install.html
+redirect_to: /11.0/install.html
 ---

--- a/overview.md
+++ b/overview.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /10.5/overview.html
+redirect_to: /11.0/overview.html
 ---

--- a/recategorizing-applications.md
+++ b/recategorizing-applications.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /11.0/recategorizing-applications.html
+---

--- a/requirements.md
+++ b/requirements.md
@@ -1,3 +1,3 @@
 ---
-redirect_to: /10.5/requirements.html
+redirect_to: /11.0/requirements.html
 ---

--- a/update.sh
+++ b/update.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-tags="v10.5.0-1.0 v10.0.0 v9.5.0"
-latest="v10.5.0-1.0"
+tags="v11.0.0-1.0 v10.5.0-1.0 v10.0.0 v9.5.0"
+latest="v11.0.0-1.0"
 
 SED=sed
 if command -v gsed > /dev/null;


### PR DESCRIPTION
This PR adds the 11.0 web pages.

It also reorganizes the table of contents for 11.0, renaming the `Usage` page to `Ingestion and Aggregation` and moving it under a new heading `Using` along with a new page `Reclassifying Applications`. These new pages were added in https://github.com/ubccr/xdmod-ondemand/pull/50.