### PR TITLE
Fix `gh-pages` update script to generate all versions.

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -1,3 +1,3 @@
-
+---
 redirect_to: /10.5/configuration.html
 ---

--- a/faq.md
+++ b/faq.md
@@ -1,3 +1,3 @@
-
+---
 redirect_to: /10.5/faq.html
 ---

--- a/install.md
+++ b/install.md
@@ -1,3 +1,3 @@
-
+---
 redirect_to: /10.5/install.html
 ---

--- a/overview.md
+++ b/overview.md
@@ -1,3 +1,3 @@
-
+---
 redirect_to: /10.5/overview.html
 ---

--- a/requirements.md
+++ b/requirements.md
@@ -1,3 +1,3 @@
-
+---
 redirect_to: /10.5/requirements.html
 ---

--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,8 @@
 
 set -e
 
-branch="main"
+tags="v10.5.0-1.0 v10.0.0 v9.5.0"
+latest="v10.5.0-1.0"
 
 SED=sed
 if command -v gsed > /dev/null;
@@ -11,23 +12,26 @@ then
     SED=gsed
 fi
 
-version=$(git show refs/remotes/upstream/main:build.json | jq --raw-output .version | cut -f 1,2 -d .)
-filelist=$(git ls-tree --name-only -r upstream/$branch docs | egrep '.*\.md$')
-for file in $filelist;
+for tag in $tags;
 do
-    outfile=$(echo $file | awk 'BEGIN{FS="/"} { for(i=2; i < NF; i++) { printf "%s/", $i } print "'$version'/" $NF}')
-    mkdir -p $(dirname $outfile)
-    sedscript='/^redirect_from:$/{N;s/^redirect_from:\n    - ""/redirect_from:\n    - "\/'$version'\/"/}'
-    if [ "$branch" = "main" ]; then
-        sedscript='/^redirect_from:$/a\    - "\/'$version'\/"'
-        basefile=$(basename $outfile .md)
-        if [ "docs/${basefile}.md" = "$file" ]; then
-            cat > ${basefile}.md << EOF
-
+    version=$(git show $tag:build.json | jq --raw-output .version | cut -f 1,2 -d .)
+    filelist=$(git ls-tree --name-only -r $tag docs | egrep '.*\.md$')
+    for file in $filelist;
+    do
+        outfile=$(echo $file | awk 'BEGIN{FS="/"} { for(i=2; i < NF; i++) { printf "%s/", $i } print "'$version'/" $NF}')
+        mkdir -p $(dirname $outfile)
+        sedscript='/^redirect_from:$/{N;s/^redirect_from:\n    - ""/redirect_from:\n    - "\/'$version'\/"/}'
+        if [ "$tag" = "$latest" ]; then
+            sedscript='/^redirect_from:$/a\    - "\/'$version'\/"'
+            basefile=$(basename $outfile .md)
+            if [ "docs/${basefile}.md" = "$file" ]; then
+                cat > ${basefile}.md << EOF
+---
 redirect_to: /$version/${basefile}.html
 ---
 EOF
+            fi
         fi
-    fi
-    git show refs/remotes/upstream/$branch:$file | $SED "$sedscript" > $outfile
+        git show $tag:$file | $SED "$sedscript" > $outfile
+    done
 done

--- a/usage.md
+++ b/usage.md
@@ -1,3 +1,3 @@
-
+---
 redirect_to: /10.5/usage.html
 ---


### PR DESCRIPTION
This PR fixes the `update.sh` script in the `gh-pages` branch to pull in the changes from each release's tag and to fix the syntax of the front matter in each of the Markdown files.

I tested this on my Mac with a cloned copy of the `gh-pages` branch of `xdmod-ondemand` and Jekyll installed. I copied in the changes from this PR, ran the commands below, and confirmed the output looks correct.
```
git submodule init
git submodule update --remote
sudo networksetup -setv6off 'Wi-Fi' # so the next commands don't hang
bundle update
bundle update --bundler
bundle install
bundle add webrick
sudo networksetup -setv6automatic 'Wi-Fi'
bundle exec jekyll serve
```