### PR TITLE
Add ingestion of page impressions for OnDemand development apps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ executors:
   rocky8-upgrade: &rocky8-upgrade-executor
     docker:
       - image: tools-ext-01.ccr.xdmod.org/xdmod-ondemand:x86_64-rockylinux8.5-v10.5.0-1.0-01
-  centos7-export-tool: &centos7-export-tool-executor
-    docker:
-      - image: centos:7
   rocky8-export-tool: &rocky8-export-tool-executor
     docker:
       - image: rockylinux:8
@@ -101,14 +98,6 @@ jobs:
     steps:
       - when:
           condition:
-            equal: [ centos7, << parameters.os >> ]
-          steps:
-            - run:
-                # This step is needed to make sure the test artifacts are checked out.
-                name: Install Git
-                command: yum install git -y
-      - when:
-          condition:
             or:
               - equal: [ rocky8, << parameters.os >> ]
               - equal: [ alma8, << parameters.os >> ]
@@ -133,17 +122,6 @@ jobs:
                   apt install git -y
       - checkout
       # Steps below come from https://osc.github.io/ood-documentation/latest/installation/install-software.html
-      - when:
-          condition:
-            equal: [ centos7, << parameters.os >> ]
-          steps:
-            - run:
-                name: Install OnDemand dependencies
-                command: |
-                  yum install centos-release-scl epel-release -y
-            - run:
-                name: Make logs directory in preparation for testing README instructions
-                command: mkdir -p /etc/httpd/logs
       - when:
           condition:
             or:
@@ -172,7 +150,6 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ centos7, << parameters.os >> ]
               - equal: [ rocky8, << parameters.os >> ]
               - equal: [ alma8, << parameters.os >> ]
               - equal: [ rocky9, << parameters.os >> ]
@@ -257,7 +234,6 @@ workflows:
           matrix:
             parameters:
               os:
-                - centos7
                 - rocky8
                 - alma8
                 - rocky9

--- a/configuration/etl/etl_data.d/ood/application-map.json
+++ b/configuration/etl/etl_data.d/ood/application-map.json
@@ -53,6 +53,7 @@
     ";^/pun/sys/vncsim/usr/([^/]+)/([^/]+).*;": "usr/$1/$2",
     ";^/pun/sys/([^/^?]+).*$;": "sys/$1",
     ";^/pun/usr/([^/]+)/([^/]+).*;": "usr/$1/$2",
+    ";^/pun/dev/([^/^?]+).*$;": "dev/$1",
     ";^/rnode/[^/]+/[^/]+/(auth-do-sign-in|auth-sign-in|auth-sign-out|auth-update-credentials|events|file_show|graphics/plot_zoom(?:_png)?|grid_data|grid_resource/gridviewer.html|help|log/log_exception|meta|p/[^/]+/terminal|rpc|session/viewhtml[^/]+/index.html)(/|\\?|$).*;": "RStudio (reverse proxy server)",
     ";^/rnode/[^/]+/[^/]+/(\\?ew=true|\\?(folder|workspace)=|login\\?(folder|to)=|mint-key|\\?reconnectionToken=|stable-|update/check|vscode-remote-resource|webview/(?:index|fake).html\\?).*;": "VS Code (reverse proxy server)",
     ";^/rnode/[^/]+/[^/]+/proxy/[^/]+/\\?vscodeBrowserReqId=.+;": "VS Code (reverse proxy server)",


### PR DESCRIPTION
## Description
This PR makes it so page impressions for OnDemand [development apps](https://osc.github.io/ood-documentation/latest/how-tos/app-development.html) are ingested.

Request paths starting with `/pun/dev/[app]` will be categorized as the app `dev/[app]`.

Previously, such page impressions were skipped by the ingestor, which emitted a warning for each skipped page impression. For example:

```
2024-07-16 23:17:28 [warning] RegexTransformIngestor ignoring 1721051620|/pun/dev/dashboard/myjobs/json|GET|-1|-1|Unknown|username|NA|NA|NA|Chrome|Windows
```

This PR also removes CentOS 7 from the `xdmod-ondemand-export` testing since CentOS 7 is EOL.

## Tests performed
I ingested logs on `xdmod-dev` from the Texas A&M ACES and Purdue Anvil resources, which have logs of development app usage, and confirmed the usage of those apps are correctly categorized and reported on the `xdmod-dev` portal.