### PR TITLE
Add index to speed up aggregation.

### DIFF
--- a/configuration/etl/etl_tables.d/ood/page_impressions.json
+++ b/configuration/etl/etl_tables.d/ood/page_impressions.json
@@ -121,7 +121,7 @@
                 ]
             },
             {
-                "name": "person_lookup",
+                "name": "agg_and_person_lookup",
                 "columns": [
                     "last_modified",
                     "person_id",

--- a/configuration/etl/etl_tables.d/ood/page_impressions.json
+++ b/configuration/etl/etl_tables.d/ood/page_impressions.json
@@ -115,7 +115,13 @@
                 "is_unique": true
             },
             {
-                "name": "agg_and_person_lookup",
+                "name": "aggregation",
+                "columns": [
+                    "log_day_id"
+                ]
+            },
+            {
+                "name": "person_lookup",
                 "columns": [
                     "last_modified",
                     "person_id",


### PR DESCRIPTION
The index is on the `log_day_id` column of the `page_impressions` table, which is used in aggregation `WHERE` conditions.

This PR also removes CentOS 7 from the `xdmod-ondemand-export` testing since CentOS 7 is EOL.