### PR TITLE
Docker file changes to support  seperate containers

### DIFF
--- a/classes/OpenXdmod/Setup/OnDemandDbSetup.php
+++ b/classes/OpenXdmod/Setup/OnDemandDbSetup.php
@@ -55,6 +55,11 @@ EOT
             'DB Admin Password:'
         );
 
+        $xdmod_host = $this->console->prompt(
+            'XDMoD Server name:',
+            'xdmod.xdmod_default'
+        );
+
         try {
 
             $sectionForDatabase = array(
@@ -67,6 +72,7 @@ EOT
                     'db_port' => $settings[$section . '_port'],
                     'db_user' => $settings[$section . '_user'],
                     'db_pass' => $settings[$section . '_pass'],
+                    'xdmod_host'=> $xdmod_host
                 );
 
                 $this->createDatabases(

--- a/configuration/etl/etl_tables.d/ood/app.json
+++ b/configuration/etl/etl_tables.d/ood/app.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "app",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/client.json
+++ b/configuration/etl/etl_tables.d/ood/client.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "client",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/location.json
+++ b/configuration/etl/etl_tables.d/ood/location.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "location",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/normalized.json
+++ b/configuration/etl/etl_tables.d/ood/normalized.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "normalized",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/os.json
+++ b/configuration/etl/etl_tables.d/ood/os.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "os",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/page_impressions.json
+++ b/configuration/etl/etl_tables.d/ood/page_impressions.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "page_impressions",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/request_method.json
+++ b/configuration/etl/etl_tables.d/ood/request_method.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "request_method",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/request_path.json
+++ b/configuration/etl/etl_tables.d/ood/request_path.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "request_path",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/reverse_proxy_host.json
+++ b/configuration/etl/etl_tables.d/ood/reverse_proxy_host.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "reverse_proxy_host",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/reverse_proxy_port.json
+++ b/configuration/etl/etl_tables.d/ood/reverse_proxy_port.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "reverse_proxy_port",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/configuration/etl/etl_tables.d/ood/staging.json
+++ b/configuration/etl/etl_tables.d/ood/staging.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "staging",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "host",

--- a/configuration/etl/etl_tables.d/ood/users.json
+++ b/configuration/etl/etl_tables.d/ood/users.json
@@ -2,8 +2,8 @@
     "table_definition": {
         "name": "users",
         "engine": "InnoDB",
-        "charset": "utf8mb4",
-        "collation": "utf8mb4_general_ci",
+        "charset": "utf8",
+        "collation": "utf8_unicode_ci",
         "columns": [
             {
                 "name": "id",

--- a/tests/scripts/setup.tcl
+++ b/tests/scripts/setup.tcl
@@ -32,6 +32,8 @@ selectMenuOption d
 
 answerQuestion {DB Admin Username} root
 providePassword {DB Admin Password:} {}
+answerQuestion {XDMoD Server name} xdmod.xdmod_default
+
 
 provideInput {Do you want to see the output*} {no}
 


### PR DESCRIPTION
## Description
### Changes to support XDMoD database on an external host

#### Added a question to get XDMoD host
- tests/scripts/setup.tcl
- classes/OpenXdmod/Setup/OnDemandDbSetup.php

#### Updated collation from utf8_general_ci to utf8_unicode_ci
- configuration/etl/etl_tables.d/ood/*


## Motivation and Context
We wanted to split up the docker containers so that each module has their own container.
This would allow us to share our docker images without having to share everything.

## Tests performed
Visited webserver and checked for on-demand data
Changed tests to match new collation sets

## Checklist:
- [ X ] The pull request description is suitable for a Changelog entry
- [ X ] The milestone is set correctly on the pull request
- [ X ] The appropriate labels have been added to the pull request
