### PR TITLE
Fix release date of v11.0.0 in changelog, add missing spec changelog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 XDMoD Open OnDemand Module Change Log
 =====================
 
-## 2024-XX-XX v11.0.0
+## 2024-09-16 v11.0.0
 
 - Change how page loads, sessions, and applications are counted and
   categorized. See the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 XDMoD Open OnDemand Module Change Log
 =====================
 
-## 2024-09-11 v11.0.0
+## 2024-XX-XX v11.0.0
 
 - Change how page loads, sessions, and applications are counted and
   categorized. See the

--- a/xdmod-ondemand.spec.in
+++ b/xdmod-ondemand.spec.in
@@ -42,5 +42,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/xdmod/
 
 %changelog
-* Wed Sep 11 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
+* Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
     - Release 11.0.0
+* Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
+    - Release 10.5.0
+* Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0
+    - Release 10.0.0
+* Fri Jul 16 2021 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
+    - Initial public release


### PR DESCRIPTION
This PR updates the changelog to set the release date for v11.0.0 to the date the RPMs were actually built instead of the date we anticipated they would be built.

It also adds missing entries to the `xdmod-ondemand.spec.in` changelog.