### PR TITLE
Add missing gh-pages pages.

### DIFF
--- a/11.0/configuration.md
+++ b/11.0/configuration.md
@@ -1,10 +1,21 @@
 
 ## Prerequisites
 
-The OnDemand module must be [installed](install.md). Optionally a GeoLite2
-geolocation database file can be [installed](requirements.md).
+The OnDemand module must be [installed](install.md). Optionally, a GeoLite2
+geolocation database file can also be [installed](requirements.md).
 
 ## Database Configuration
+
+### Manual configuration
+
+If the database server is located on a different host than the webserver, then it is necessary
+to set up the database manually. Otherwise, it can be set up interactively instead per the
+next section below.
+
+To set up the database manually, create a database schema called `modw_ondemand` and grant permission for the XDMoD database user
+account to access this schema.
+
+Once the schema is created, the `acl-config` command should be run.
 
 ### Interactive script configuration
 
@@ -12,26 +23,14 @@ The Open OnDemand XDMoD module adds an additional menu item to the XDMoD interac
 
     # xdmod-setup
 
-and select the ‘Open OnDemand’ option in the main menu. The Open OnDemand
+and select the "Open OnDemand" option in the main menu. The Open OnDemand
 section only has a single option: setup the database.  This option creates the
 necessary database schema in the XDMoD
-datawarehouse. You will need to provide the credentials for your MySQL root
+data warehouse. You will need to provide the credentials for your MySQL root
 user, or another user that has privileges to create databases. A single
-database `modw_ondemand` will be created.  The database user that is
+schema `modw_ondemand` will be created.  The database user that is
 specified in the `portal_settings.ini` will be granted access to this
-database.
-
-### Manual configuration
-
-If the database server is located on a different host than the webserver then it is necessary
-to setup the database manually.
-
-Create a database schema called `modw_ondemand` and grant permission for the XDMoD database user
-account to access this schema.
-
-Once the schema is created then the `acl-config` command should be run:
-
-    $ /usr/xdmod/bin/acl-config
+schema.
 
 ## Resource Setup
 
@@ -41,19 +40,19 @@ Instructions for adding the resource are on the [main Open XDMoD page](https://o
 The Open OnDemand resource must have a type set to `gateway`.
 
 The resource setup menu will prompt for the node and core count for the resource. These
-data are not currently used by the On Demand module, but it is recommmended to use the
+data are not currently used by the OnDemand module, but it is recommmended to use the
 correct core and node counts for the Open OnDemand webserver for consistency.
 
-**The `xdmod-ingestor` script must be run after the new resource is added**. Running
+**The `xdmod-ingestor` command must be run after the new resource is added**. Running
 `xdmod-ingestor` loads the resource information into the XDMoD datawarehouse.
 
 ## Configuration file
 
 The `/etc/xdmod/portal_settings.d/ondemand.ini` configuration
-file settting are listed below:
+file settings are listed below:
 
 | Parameter Name |  Description
 | -------------- | -----------
 | `geoip_database`       | Full path to the GeoLite2 City file (in MMDB format). Set this to an empty string if no file is available (location data in XDMoD will show as Unknown). |
-| `webserver_format_str` | The format string for the webserver access logs. This should be set to the same value as the `LogFormat` directive in the apache server for the Open OnDemand instance |
+| `webserver_format_str` | The format string for the webserver access logs. This should be set to the same value as the `LogFormat` directive in the apache server for the Open OnDemand instance. |
 

--- a/11.0/faq.md
+++ b/11.0/faq.md
@@ -9,12 +9,12 @@ or Center Staff role. Note the admin user account that is created with `xdmod-se
 
 Re-run the `xdmod-ondemand-ingestor` command with the `--debug` flag to show detailed information
 about what it is running. Things to double check:
-- The `webserver_format_str` setting matches the data format in the log files
-- The filenames of the log files end in `.log` or `.log.N` where `N` is a number
+- The `webserver_format_str` setting matches the data format in the log files.
+- The filenames of the log files end in `.log` or `.log.N` where `N` is a number.
 
 ## The xdmod-ondemand-ingestor command fails with out of memory error
 
-If the memory usage of the `xdmod-ondemand-ingestor` command reaches the php memory limit
+If the memory usage of the `xdmod-ondemand-ingestor` command reaches the PHP memory limit
 then it will exit with an error message similar to the one shown below
 ```
 PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to allocate 86 bytes) in /usr/share/xdmod/vendor/kassner/log-parser/src/Kassner/LogParser/LogParser.php on line 113
@@ -23,4 +23,4 @@ PHP Fatal error:  Allowed memory size of 134217728 bytes exhausted (tried to all
 This memory error is caused because the `xdmod-ondemand-ingestor` command loads all records in a
 log file into memory before loading into the database. This error can be mitigated by either
 splitting the log file into multiple smaller files (described in the [Hints](ingestion-aggregation.md#hints)) or
-by increasing the php memory limit setting.
+by increasing the PHP memory limit setting.

--- a/11.0/ingestion-aggregation.md
+++ b/11.0/ingestion-aggregation.md
@@ -1,8 +1,8 @@
 ## Prerequisites:
-1. The OnDemand module [installed](install.md)
-2. The database schema has been [created](configuration.md#database-configuration)
-3. The OnDemand resource has been [added](configuration.md#resource-setup)
-4. The `portal_settings.d/ondemand.ini` configuration file [edited as needed](configuration.md#configuration-file)
+1. The OnDemand module has been [installed](install.md).
+2. The database schema has been [created](configuration.md#database-configuration).
+3. The OnDemand resource has been [added](configuration.md#resource-setup).
+4. The `portal_settings.d/ondemand.ini` configuration file has been [edited as needed](configuration.md#configuration-file).
 
 ## Ingest and Aggregate
 
@@ -10,8 +10,8 @@ The OnDemand weblog ingestion pipeline requires two parameters:
 
 | Parameter Name | Description
 | -------------- | -----------
-| `-r` or `--resource` | Must be set to the name of the resource when it was added to XDMoD in the `xdmod-setup` command. |
-| `-d` or `--dir` | Set to the path to a directory containing webserver log files from the Open OnDemand server. The ingestor will process all files in this directory that have the suffix `.log` or `.log.X` where X is a number |
+| `-r` or `--resource` | The name of the resource when it was added to XDMoD in the `xdmod-setup` command. |
+| `-d` or `--dir` | The path to a directory containing webserver log files from the Open OnDemand server. The ingestor will process all files in this directory that have the suffix `.log` or `.log.X` where X is a number. |
 
 
 The pipeline should be run as the `xdmod` user as follows:
@@ -30,7 +30,7 @@ The run only the aggregation pipeline, include the `-a` or `--aggregate` paramet
 
 For log files with a large amount of data (hundreds of thousands of lines), the ingestion pipeline
 will use less memory and run faster if you split large log files into smaller ones. An example of how to do this
-is to use the `split` commandline tool to split the large log file by lines and generate
+is to use the `split` command line tool to split the large log file by lines and generate
 output files with a numbered suffix (note the period at the end of the output filename):
 
 ```bash

--- a/11.0/install.md
+++ b/11.0/install.md
@@ -6,17 +6,15 @@ for setup and install instructions.
 
 ## Source code install
 
-The source package is installed as follows:
+The source package is installed as follows. Change the prefix to match the directory where Open XDMoD is installed.
 
-    $ tar zxvf xdmod-ondemand-{{ page.sw_version }}.tar.gz
-    $ cd xdmod-ondemand-{{ page.sw_version }}
-    # ./install --prefix=/opt/xdmod
-
-Change the prefix as desired. The default installation prefix is `/usr/local/xdmod`. These instructions assume you are installing Open XDMoD in `/opt/xdmod`.
+    # tar zxvf xdmod-ondemand-{{ page.sw_version }}.tar.gz
+    # cd xdmod-ondemand-{{ page.sw_version }}
+    # ./install --prefix=/usr/local/xdmod
 
 ## RPM install
 
-    # yum install xdmod-ondemand-{{ page.sw_version }}-1.0.el7.noarch.rpm
+    # dnf install xdmod-ondemand-{{ page.sw_version }}-1.0.el8.noarch.rpm
 
 ## Next Step
 

--- a/11.0/overview.md
+++ b/11.0/overview.md
@@ -7,10 +7,10 @@ The XDMoD Open OnDemand Module is an optional module for
 tracking usage of the Open OnDemand software in XDMoD.
 
 For more information about Open OnDemand please visit
-[the Open OnDemand website](https://openondemand.org/)
+[the Open OnDemand website](https://openondemand.org/).
 
-For more information, including information about additional Open XDMoD
-capabilities provided as optional modules, please visit
+For more information about Open XDMoD, including information about additional
+Open XDMoD capabilities provided as optional modules, please visit
 [the Open XDMoD website](https://open.xdmod.org).
 
 The OnDemand module provides an "OnDemand" realm in XDMoD.

--- a/11.0/upgrade.md
+++ b/11.0/upgrade.md
@@ -1,0 +1,207 @@
+---
+title: Upgrade Guide
+---
+
+General Upgrade Notes
+---------------------
+
+The XDMoD OnDemand module should be upgraded at the same time as the main Open
+XDMoD software. The upgrade procedure is documented on the [XDMoD upgrade
+page](https://open.xdmod.org/upgrade.html). Downloads of RPMs and source
+packages for the XDMoD OnDemand module are available from
+[GitHub][github-latest-release].
+
+Additional 11.0.0 Upgrade Notes
+-------------------
+
+Open XDMoD 11.0.0 fundamentally changes how page loads, sessions, and
+applications are counted and categorized, as described in detail in the
+sections below. The changes only apply to newly ingested Open OnDemand web
+server logs after upgrading to 11.0.0. If you have already ingested logs with a
+prior version of Open XDMoD, those logs will not be able to be recounted and
+recategorized using the new methods from 11.0.0 unless you still have copies of
+the original log files, in which case you can delete the corresponding rows
+from the `modw_ondemand.page_impressions` database table and reingest and
+reaggregate the logs following the instructions below:
+
+1. Back up the `modw_ondemand.page_impressions` database table (e.g., using
+`mysqldump`).
+1. Run the Bash loop below in the directory containing the log files to find
+the earliest and latest timestamps in the logs:
+    ```bash
+    earliest=9999999999;
+    latest=0;
+    while read line; do
+        current=$(date -d "$line" +"%s");
+        if [ $current -lt $earliest ]; then
+            earliest=$current;
+        fi;
+        if [ $current -gt $latest ]; then
+            latest=$current;
+        fi;
+    done < <(cat *.log* | cut -d ']' -f 1 | cut -d '[' -f 2 | sed 's#/#-#g' | sed 's/:/ /');
+    echo -e "Earliest: $earliest\nLatest: $latest"
+    ```
+1. Run the SQL command below to list the page impressions that will be deleted,
+replacing `:earliest` with the earliest timestamp and `:latest` with the latest
+timestamp obtained in the previous step:
+    ```sql
+    SELECT *
+    FROM modw_ondemand.page_impressions
+    WHERE log_time_ts BETWEEN :earliest AND :latest
+    ```
+1. If that is the correct list of page impressions you want to delete, run the
+same SQL command from the previous step, replacing `SELECT *` with `DELETE`.
+1. Reingest and reaggregate the logs following
+[these instructions](ingestion-aggregation.md).
+
+The sections below explain the details of the changes in 11.0.0.
+
+### Using request path instead of Referer header
+
+In previous versions, during ingestion of the Open OnDemand web server logs,
+the Referer header of each line was used to determine which application was
+being requested for that line. For example, take the following line from a web
+server log file:
+
+```
+127.0.0.1 - sfoster [21/Feb/2024:22:30:56 +0000] "GET /pun/sys/dashboard/batch_connect/sys/jupyter/session_contexts/new HTTP/1.1" 200 13058 "https://resource.example.com/pun/sys/dashboard" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+```
+
+In this example, the Referer header is
+`https://localhost:3443/pun/sys/dashboard`, so prior to 11.0.0, this would be
+counted as a request for the `sys/dashboard` application. However, the Referer
+header actually indicates from which page the request originated, not the page
+that is actually being requested. The actual application being requested on
+this line is indicated by the request path,
+`/pun/sys/dashboard/batch_connect/sys/jupyter/session_contexts/new`, which
+would be the `sys/jupyter` application. In version 11.0.0, the request path is
+now used to determine which application was being requested.
+
+For more information on how applications are categorized, including
+instructions for how to recategorize them, see
+[this page](recategorizing-applications.md).
+
+In order to enable parsing of the request path (and the request method, which
+is not currently displayed in the XDMoD portal but is used for deduplication
+and may be displayed in a future version), the `webserver_format_str` defined
+in `portal_settings.d/ondemand.ini` must include either `%r` or both of `%m`
+and `%U`.
+
+11.0.0 also changes the criteria used for deduplicating page impressions. Prior
+to 11.0.0, only the request time, user, and application were used. In 11.0.0,
+the resource, request path, request method, reverse proxy host and port (if
+applicable), browser geolocation (if applicable), browser family, and OS family
+are also used to deduplicate page impressions.
+
+### Removal of `-u` / `--url` option from `xdmod-ondemand-ingestor`
+
+Prior to 11.0.0, logs would only be ingested if the Referer header matched the
+value of the `-u` or `--url` option to `xdmod-ondemand-ingestor`. For example,
+if the Referer header were `https://resource.example.com/pun/sys/dashboard`,
+then the ingestor would only ingest the line if the `-u
+https://resource.example.com` or `--url https://resource.example.com` option
+were passed to `xdmod-ondemand-ingestor`. Now, the Referer header is not used,
+so the `-u` / `--url` option is removed from `xdmod-ondemand-ingestor`. All
+page impressions in the file(s) being ingested will be assigned to the resource
+specified by the `-r` or `--resource` option to `xdmod-ondemand-ingestor`.
+
+### Separation of ingestion and aggregation steps
+
+Prior to 11.0.0, `xdmod-ondemand-ingestor` would always run both ingestion and
+aggregation. In 11.0.0, ingestion and aggregation can now be run as separate
+steps. The usage is explained on [this page](ingestion-aggregation.md).
+
+### Inclusion of reverse proxy hosts and ports
+
+In Open OnDemand, requests can be reverse proxied to other servers such as
+Jupyter notebook servers, RStudio servers, VNC servers, etc. (details
+[here](https://osc.github.io/ood-documentation/latest/how-tos/app-development/interactive/setup/enable-reverse-proxy.html)).
+Prior to Open XDMoD 11.0.0, such requests were not counted in XDMoD. In 11.0.0,
+such requests are now counted, and the reverse proxy host and port are
+preserved in the `modw_ondemand.page_impressions` table (but the host and port
+are not currently displayed in the XDMoD portal; they may be in a future
+version).
+
+### Exclusion of non page impressions
+
+In 11.0.0, requests for app icons, images, stylesheets, scripts, datafiles,
+etc. are not counted as page impressions unless they were being loaded from
+the OnDemand "Files" or "File Editor" applications. Requests are only ingested
+if the request path starts with `/pun/`, `/node/`, or `/rnode/`; the request is
+from an authenticated user (i.e., not `"-"`); and the request is not for one of
+the excluded file extensions from the list below (this is defined in the
+configuration file `etl/etl_action_defs.d/ood/normalized.json`).
+
+```
+aff, css, dic, eot, gif, ico, jpeg, jpg, js, json, map, mp3, oga, ogg, otf, png, rstheme, svg, ttf, wasm, woff, woff2
+```
+
+### Removing `ihpc` from application names
+
+Prior to 11.0.0, some applications were given a name with `(sys/ihpc)` at the
+end. `iHPC` is an old name for interactive OnDemand apps; this name is no
+longer used. In 11.0.0, page impressions that are ingested will no longer have
+`(sys/ihpc)` in their application names. Applications for page impressions
+that have already been ingested can be recategorized as explained on
+[this page](recategorizing-applications.md).
+
+### Speeding up person lookup
+
+Prior to 11.0.0, each time ingestion was run, the ingestor would try to match
+the username of all unknown people from the `modw_ondemand.page_impressions`
+table with usernames from the `modw.systemaccount` table. 11.0.0 still does
+this, but rather than doing so for all unknown people in the table, it only
+does it for the page impressions that were ingested during the current run of
+`xdmod-ondemand-ingestor`. This speeds up the overall ingestion.
+
+### Allowing `@` in usernames
+
+The `xdmod-ondemand-ingestor` now allows the `@` character to appear in
+ingested usernames.
+
+### Configuration File Changes
+
+The upgrade renames `etl/etl_data.d/ood/application_map.json` to
+`etl/etl_data.d/ood/application-map.json` and updates it with additional
+application mappings. See [this page](recategorizing-applications.md) for
+information on how to recategorize applications.
+
+### Database Changes
+
+During the upgrade, the `modw_ondemand.staging` table will have its
+`header_referer` column removed and columns added for `request_method` and
+`request_path`.
+
+The `modw_ondemand.normalized` table will be truncated during the upgrade. It
+will also receive new columns for `id` (which is now its primary key),
+`request_path`, `request_method`, `reverse_proxy_host`, and
+`reverse_proxy_port`. Its unique index will be updated to no longer include
+`app` and to include `request_path`, `request_method`, `ua_family`, and
+`ua_os_family`. In order to fit the new index, the `ua_family` and
+`ua_os_family` columns are downsized from `VARCHAR(255)` to `VARCHAR(32)`.
+
+During the upgrade, the `modw_ondemand.page_impressions` table will have its
+`id` column updated to use `bigint(20) unsigned` instead of `int(11)` to be
+able to accommodate more than 2,147,483,647 page impressions. It will also have
+columns added for `request_path_id`, `request_method_id`,
+`reverse_proxy_host_id`, and `reverse_proxy_port_id`. Its unique index will be
+updated to remove `app_id` and to include `resource_id`, `request_path_id`,
+`request_method_id`, `reverse_proxy_host_id`, `reverse_proxy_port_id`,
+`app_id`, `location_id`, `ua_family_id`, and `ua_os_family_id`. Indexes will be
+added to speed up aggregation, person lookup, and application recategorization.
+
+If the `modw_ondemand.location` table has a row with `unknown` as its value for
+`city`, `state`, and `country`; and `Unknown` as its value for `name`; the
+upgrade will change the values for `city`, `state`, and `country` to `NA` for
+that row.
+
+The upgrade will add tables for `modw_ondemand.request_method`,
+`modw_ondemand.request_path`, `modw_ondemand.reverse_proxy_host`, and
+`modw_ondemand.reverse_proxy_port`.
+
+During the upgrade, if the `modw_ondemand.location` table has a row with
+`unknown` as its value for `city`, `state`, and `country`, these will be
+replaced with the value `NA`.
+
+[github-latest-release]: https://github.com/ubccr/xdmod-ondemand/releases/latest

--- a/update.sh
+++ b/update.sh
@@ -3,8 +3,8 @@
 
 set -e
 
-tags="v11.0.0-1.0 v10.5.0-1.0 v10.0.0 v9.5.0"
-latest="v11.0.0-1.0"
+branches="xdmod11.0 xdmod10.5 xdmod10.0 xdmod9.5"
+latest="xdmod11.0"
 
 SED=sed
 if command -v gsed > /dev/null;
@@ -12,16 +12,16 @@ then
     SED=gsed
 fi
 
-for tag in $tags;
+for branch in $branches;
 do
-    version=$(git show $tag:build.json | jq --raw-output .version | cut -f 1,2 -d .)
-    filelist=$(git ls-tree --name-only -r $tag docs | egrep '.*\.md$')
+    version=${branch:5}
+    filelist=$(git ls-tree --name-only -r upstream/$branch docs | egrep '.*\.md$')
     for file in $filelist;
     do
         outfile=$(echo $file | awk 'BEGIN{FS="/"} { for(i=2; i < NF; i++) { printf "%s/", $i } print "'$version'/" $NF}')
         mkdir -p $(dirname $outfile)
         sedscript='/^redirect_from:$/{N;s/^redirect_from:\n    - ""/redirect_from:\n    - "\/'$version'\/"/}'
-        if [ "$tag" = "$latest" ]; then
+        if [ "$branch" = "$latest" ]; then
             sedscript='/^redirect_from:$/a\    - "\/'$version'\/"'
             basefile=$(basename $outfile .md)
             if [ "docs/${basefile}.md" = "$file" ]; then
@@ -32,6 +32,6 @@ redirect_to: /$version/${basefile}.html
 EOF
             fi
         fi
-        git show $tag:$file | $SED "$sedscript" > $outfile
+        git show refs/remotes/upstream/$branch:$file | $SED "$sedscript" > $outfile
     done
 done

--- a/upgrade.md
+++ b/upgrade.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /11.0/upgrade.html
+---


### PR DESCRIPTION
This PR fixes the `gh-pages` `update.sh` script to use branches instead of tags, and it adds missing pages from the 11.0 website.