### PR TITLE
Remove specific `xdmod` branch from CircleCI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - run:
           name: Checkout XDMoD
           command: |
-            git clone --depth=1 --branch=xdmod11.0 https://github.com/ubccr/xdmod.git $XDMOD_SRC_DIR
+            git clone --depth=1 https://github.com/ubccr/xdmod.git $XDMOD_SRC_DIR
       - run:
           name: Link the module into the XDMoD Source Directory
           command: |


### PR DESCRIPTION
This PR removes the specification of the `xdmod` repo branch since the default branch is what is desired.