### PR TITLE
Update changelog for 11.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 XDMoD Open OnDemand Module Change Log
 =====================
 
+## XXXX-XX-XX v11.0.1
+
 ## 2024-09-11 v11.0.0
 
 - Change how page loads, sessions, and applications are counted and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,19 @@ XDMoD Open OnDemand Module Change Log
 
 ## XXXX-XX-XX v11.0.1
 
-- Add website table of contents template ([\#65](https://github.com/ubccr/xdmod-ondemand/pull/65)).
+- Bug Fixes
+    - Fix request path filtering of File Editor page impressions
+      ([\#78](https://github.com/ubccr/xdmod-ondemand/pull/78)).
+    - Fix application mapping of noVNC page impressions
+      ([\#70](https://github.com/ubccr/xdmod-ondemand/pull/70)).
+    - Fix how reverse proxy ports and request methods are stored
+      ([\#72](https://github.com/ubccr/xdmod-ondemand/pull/72)).
+- Documentation
+    - Add upgrade guide
+      ([\#56](https://github.com/ubccr/xdmod-ondemand/pull/56)).
+- Miscellaneous
+    - Add website table of contents template
+      ([\#65](https://github.com/ubccr/xdmod-ondemand/pull/65)).
 
 ## 2024-09-11 v11.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ XDMoD Open OnDemand Module Change Log
     - Fix application mapping of noVNC page impressions
       ([\#70](https://github.com/ubccr/xdmod-ondemand/pull/70)).
     - Fix how reverse proxy ports and request methods are stored
-      ([\#72](https://github.com/ubccr/xdmod-ondemand/pull/72)).
+      ([\#72](https://github.com/ubccr/xdmod-ondemand/pull/72),
+      ([\#84](https://github.com/ubccr/xdmod-ondemand/pull/84))).
 - Documentation
     - Add upgrade guide
       ([\#56](https://github.com/ubccr/xdmod-ondemand/pull/56)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 XDMoD Open OnDemand Module Change Log
 =====================
 
-## XXXX-XX-XX v11.0.1
+## 2025-03-17 v11.0.1
 
 - Bug Fixes
     - Fix request path filtering of File Editor page impressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ XDMoD Open OnDemand Module Change Log
     - Add website table of contents template
       ([\#65](https://github.com/ubccr/xdmod-ondemand/pull/65)).
 
-## 2024-09-11 v11.0.0
+## 2024-09-16 v11.0.0
 
 - Change how page loads, sessions, and applications are counted and
   categorized. See the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ XDMoD Open OnDemand Module Change Log
 
 ## XXXX-XX-XX v11.0.1
 
+- Add website table of contents template ([\#65](https://github.com/ubccr/xdmod-ondemand/pull/65)).
+
 ## 2024-09-11 v11.0.0
 
 - Change how page loads, sessions, and applications are counted and

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
     "name": "xdmod-ondemand",
     "version": "11.0.1",
-    "release": "rc.3",
+    "release": "1",
     "files": {
         "include_paths": [
         ],

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -199,10 +199,6 @@ that row.
 The upgrade will add tables for `modw_ondemand.request_method`,
 `modw_ondemand.request_path`, and `modw_ondemand.reverse_proxy_host`.
 
-During the upgrade, if the `modw_ondemand.location` table has a row with
-`unknown` as its value for `city`, `state`, and `country`, these will be
-replaced with the value `NA`.
-
 11.0.1 Upgrade Notes
 -------------------
 

--- a/xdmod-ondemand.spec.in
+++ b/xdmod-ondemand.spec.in
@@ -42,8 +42,6 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/xdmod/
 
 %changelog
-* XXX XXX XX XXXX XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.1-1.0
-    - Release 11.0.1
 * Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
     - Release 11.0.0
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0

--- a/xdmod-ondemand.spec.in
+++ b/xdmod-ondemand.spec.in
@@ -42,5 +42,11 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/xdmod/
 
 %changelog
-* Wed Sep 11 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
+* Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
     - Release 11.0.0
+* Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
+    - Release 10.5.0
+* Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0
+    - Release 10.0.0
+* Fri Jul 16 2021 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
+    - Initial public release

--- a/xdmod-ondemand.spec.in
+++ b/xdmod-ondemand.spec.in
@@ -42,11 +42,13 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/xdmod/
 
 %changelog
+* Mon Mar 17 2025 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.1-1
+- Release 11.0.1
 * Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
-    - Release 11.0.0
+- Release 11.0.0
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
-    - Release 10.5.0
+- Release 10.5.0
 * Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0
-    - Release 10.0.0
+- Release 10.0.0
 * Fri Jul 16 2021 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
-    - Initial public release
+- Initial public release

--- a/xdmod-ondemand.spec.in
+++ b/xdmod-ondemand.spec.in
@@ -42,6 +42,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/xdmod/
 
 %changelog
+* XXX XXX XX XXXX XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.1-1.0
+    - Release 11.0.1
 * Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
     - Release 11.0.0
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0


### PR DESCRIPTION
Same as https://github.com/ubccr/xdmod/pull/1950 for the `xdmod-ondemand` module.

This PR also removes a redundant instruction from the upgrade docs.