### PR TITLE
Add link in TOC to upgrade guide.

### DIFF
--- a/_data/v11_0toc.yml
+++ b/_data/v11_0toc.yml
@@ -15,6 +15,8 @@ toc:
         url: /11.0/install.html
       - page: Configuration Guide
         url: /11.0/configuration.html
+      - page: Upgrade Guide
+        url: /11.0/upgrade.html
   - title: Using
     subfolderitems:
       - page: Ingestion and Aggregation


### PR DESCRIPTION
This PR adds a missing link to the upgrade guide in the 11.0 table of contents.