### PR TITLE
Update changelog for 11.0.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 XDMoD Open OnDemand Module Change Log
 =====================
 
+## XXXX-XX-XX v11.5.0
+
 ## 2024-09-16 v11.0.0
 
 - Change how page loads, sessions, and applications are counted and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ XDMoD Open OnDemand Module Change Log
       ([\#79](https://github.com/ubccr/xdmod-ondemand/pull/79)).
     - Fix application mapping of noVNC page impressions
       ([\#79](https://github.com/ubccr/xdmod-ondemand/pull/79)).
+    - Fix how reverse proxy ports and request methods are stored
+      ([\#79](https://github.com/ubccr/xdmod-ondemand/pull/79)).
 - Documentation
     - Add upgrade guide
       ([\#56](https://github.com/ubccr/xdmod-ondemand/pull/56)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ XDMoD Open OnDemand Module Change Log
 
 ## XXXX-XX-XX v11.0.1
 
-- Add website table of contents template ([\#76](https://github.com/ubccr/xdmod-ondemand/pull/76)).
+- Bug Fixes
+    - Fix request path filtering of File Editor page impressions
+      ([\#79](https://github.com/ubccr/xdmod-ondemand/pull/79)).
+    - Fix application mapping of noVNC page impressions
+      ([\#79](https://github.com/ubccr/xdmod-ondemand/pull/79)).
+- Documentation
+    - Add upgrade guide
+      ([\#56](https://github.com/ubccr/xdmod-ondemand/pull/56)).
+- Miscellaneous
+    - Add website table of contents template
+      ([\#76](https://github.com/ubccr/xdmod-ondemand/pull/76)).
 
 ## 2024-09-16 v11.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ XDMoD Open OnDemand Module Change Log
 
 ## XXXX-XX-XX v11.0.1
 
-- Add website table of contents template ([\#74](https://github.com/ubccr/xdmod-ondemand/pull/74)).
+- Add website table of contents template ([\#76](https://github.com/ubccr/xdmod-ondemand/pull/76)).
 
 ## 2024-09-16 v11.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ XDMoD Open OnDemand Module Change Log
 
 ## XXXX-XX-XX v11.5.0
 
+## XXXX-XX-XX v11.0.1
+
+- Add website table of contents template ([\#74](https://github.com/ubccr/xdmod-ondemand/pull/74)).
+
 ## 2024-09-16 v11.0.0
 
 - Change how page loads, sessions, and applications are counted and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 XDMoD Open OnDemand Module Change Log
 =====================
 
-## XXXX-XX-XX v11.5.0
-
 ## 2025-03-17 v11.0.1
 
 - Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ XDMoD Open OnDemand Module Change Log
 
 ## XXXX-XX-XX v11.5.0
 
-## XXXX-XX-XX v11.0.1
+## 2025-03-17 v11.0.1
 
 - Bug Fixes
     - Fix request path filtering of File Editor page impressions

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
     "name": "xdmod-ondemand",
     "version": "11.5.0",
-    "release": "1.0",
+    "release": "1",
     "files": {
         "include_paths": [
         ],

--- a/xdmod-ondemand.spec.in
+++ b/xdmod-ondemand.spec.in
@@ -42,11 +42,13 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/xdmod/
 
 %changelog
+* Mon Mar 17 2025 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.1-1
+- Release 11.0.1
 * Mon Sep 16 2024 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 11.0.0-1.0
-    - Release 11.0.0
+- Release 11.0.0
 * Mon Sep 11 2023 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.5.0-1.0
-    - Release 10.5.0
+- Release 10.5.0
 * Thu Mar 10 2022 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 10.0.0-1.0
-    - Release 10.0.0
+- Release 10.0.0
 * Fri Jul 16 2021 XDMoD <ccr-xdmod-list@listserv.buffalo.edu> 9.5.0-1.0
-    - Initial public release
+- Initial public release


### PR DESCRIPTION
Port of https://github.com/ubccr/xdmod-ondemand/pull/73 for the `main` branch.