### PR TITLE
Update RPM name in docs.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ The source package is installed as follows. Change the prefix to match the direc
 
 ## RPM install
 
-    # dnf install xdmod-ondemand-{{ page.sw_version }}-1.0.el8.noarch.rpm
+    # dnf install xdmod-ondemand-{{ page.sw_version }}-1.el8.noarch.rpm
 
 ## Next Step
 


### PR DESCRIPTION
Port of https://github.com/ubccr/xdmod-ondemand/pull/89 for `main` branch.